### PR TITLE
Add type "module" declaration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@metrological/sdk",
   "version": "1.0.0",
   "license": "Apache-2.0",
+  "type": "module",
   "scripts": {
     "lint": "eslint '**/*.js'",
     "release": "npm publish --access public"


### PR DESCRIPTION
Because the `index.js` exported by this project is an ES module it's nearest package.json should declare:
```
type: "module"
```
Outside of node, packages like jest use this to determine the style of export used by a package.