### PR TITLE
Update unload signature in videoplayer.md

### DIFF
--- a/docs/plugins/videoplayer.md
+++ b/docs/plugins/videoplayer.md
@@ -143,7 +143,7 @@ The custom unloader function has to return a Promise that is resolved as soon as
 
 ```js
 // Note: this is in fact the default unloader function
-const myUnloader = (url, videoEl, config) => {
+const myUnloader = videoEl => {
   new Promise(resolve => {
     videoEl.removeAttribute('src')
     videoEl.load()


### PR DESCRIPTION
Hello, I noticed in the docs that it suggest `unloader` takes a function with the same signature as `loader` but that's not the case, it only takes a single argument which is the `videoEl`. 

https://github.com/Metrological/metrological-sdk/blob/master/src/VideoPlayer/index.js#L107