### PR TITLE
VideoPlayer fires non API-compliant error event

### DIFF
--- a/docs/plugins/videoplayer.md
+++ b/docs/plugins/videoplayer.md
@@ -447,8 +447,13 @@ The second argument of a catch-all hook is the (already mentioned) Object contai
 
 The third argument is the `currentTime` of the video.
 
+```js
 $videoPlayerEvent(eventName, videoElement, currentTime) {
-  console.log(eventname, videoElement, currentTime)}### Event Overview
+  console.log(eventname, videoElement, currentTime)
+}
+```
+
+### Event Overview
 
 The available events are:
 

--- a/src/VideoPlayer/index.js
+++ b/src/VideoPlayer/index.js
@@ -288,6 +288,11 @@ const videoPlayerPlugin = {
     if (!this.canInteract) return
     if (textureMode === true) videoTexture.start()
     executeAsPromise(videoEl.play, null, videoEl).catch(e => {
+      fireOnConsumer('Error', { videoElement: videoEl, event: e })
+
+      // This is not API-compliant, as it results in firing "$videoPlayererror" rather than "$videoPlayerError".
+      // See docs here for API-compliant events -> https://github.com/Metrological/metrological-sdk/blob/master/docs/plugins/videoplayer.md#event-overview
+      // It has been kept for backwards compatability for library consumers who may have already written handler functions to match it.
       fireOnConsumer('error', { videoElement: videoEl, event: e })
     })
   },

--- a/src/VideoPlayer/index.js
+++ b/src/VideoPlayer/index.js
@@ -244,6 +244,11 @@ const videoPlayerPlugin = {
               this.play()
             })
             .catch(e => {
+              fireOnConsumer('Error', { videoElement: videoEl, event: e })
+        
+              // This is not API-compliant, as it results in firing "$videoPlayererror" rather than "$videoPlayerError".
+              // See docs here for API-compliant events -> https://github.com/Metrological/metrological-sdk/blob/master/docs/plugins/videoplayer.md#event-overview
+              // It has been kept for backwards compatability for library consumers who may have already written handler functions to match it.
               fireOnConsumer('error', { videoElement: videoEl, event: e })
             })
         })


### PR DESCRIPTION
This change introduces the firing of an API-compliant error event in the VideoPlayer, where previously a non-compliant error event was fired.

The non-compliant error has been retained for backwards compatibility.